### PR TITLE
Replaced 'rails' gem requirement with 'activesupport', 'actionpack', and 'railties'

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -14,9 +14,12 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "haml-rails"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "rails", "~>3.0.0"
+  s.add_dependency "activesupport", "~> 3.0.0"
+  s.add_dependency "actionpack", "~> 3.0.0"
+  s.add_dependency "railties", "~> 3.0.0"
   s.add_dependency "haml", "~>3.0.18"
-  s.add_development_dependency "bundler", ">= 1.0.0"
+  s.add_development_dependency "rails", "~> 3.0.0"
+  s.add_development_dependency "bundler", "~> 1.0.0"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").select{|f| f =~ /^bin/}


### PR DESCRIPTION
In order to improve the agnosticism of haml-rails, I replaced the 'rails' gem requirement with more specific Rails libraries. This prevents the need to install and load ActiveRecord and other unnecessary gems just to use the Haml template engine.

Without this patch, trying to use an alternate ORM like DataMapper with haml-rails will also require ActiveRecord, which defeats the purpose of ORM agnosticism.
