### PR TITLE
Added :ugly option

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -9,6 +9,7 @@ module Haml
       config.before_initialize do
         Haml.init_rails(binding)
         Haml::Template.options[:format] = :html5
+        Haml::Template.options[:ugly] = true
       end
     end
   end


### PR DESCRIPTION
I added the :ugly option for speed see
http://nex-3.com/posts/87-haml-benchmark-numbers-for-2-2

Typically I use firebug when viewing the output of templates... So I don't really see a downside to turning ugly on.
