### PR TITLE
update dep versions, especially haml, for rails 3.2 compat

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "haml-rails"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "haml",          "~> 3.0"
-  s.add_dependency "activesupport", "~> 3.0"
-  s.add_dependency "actionpack",    "~> 3.0"
-  s.add_dependency "railties",      "~> 3.0"
+  s.add_dependency "haml",          "~> 3.1"
+  s.add_dependency "activesupport", "~> 3.2"
+  s.add_dependency "actionpack",    "~> 3.2"
+  s.add_dependency "railties",      "~> 3.2"
 
-  s.add_development_dependency "rails",   "~> 3.0"
+  s.add_development_dependency "rails",   "~> 3.2"
   s.add_development_dependency "bundler", "~> 1.0.0"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
I think all that needs to happen is to update the gems

Fixes #18
