### PR TITLE
revert rails and action* dependencies for Rails 3.(0|1) compat

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "haml",          "~> 3.1"
-  s.add_dependency "activesupport", "~> 3.2"
-  s.add_dependency "actionpack",    "~> 3.2"
-  s.add_dependency "railties",      "~> 3.2"
+  s.add_dependency "activesupport", "~> 3.0"
+  s.add_dependency "actionpack",    "~> 3.0"
+  s.add_dependency "railties",      "~> 3.0"
 
-  s.add_development_dependency "rails",   "~> 3.2"
+  s.add_development_dependency "rails",   "~> 3.0"
   s.add_development_dependency "bundler", "~> 1.0.0"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
Based on conversations in #21.
