### PR TITLE
Changes b tag to strong

### DIFF
--- a/lib/generators/haml/scaffold/templates/show.html.haml
+++ b/lib/generators/haml/scaffold/templates/show.html.haml
@@ -2,7 +2,7 @@
 
 <% for attribute in attributes -%>
 %p
-  %b <%= attribute.human_name %>:
+  %strong <%= attribute.human_name %>:
   = @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
 


### PR DESCRIPTION
The change is made due to importance of the attribute name (e.g. <strong>Name:</strong>) on the page (versus just stylistic / appearance sake tag).
