### PR TITLE
Fix tests for Rails 3.2

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ Rails.application.config.root = Rails.root
 
 # Call configure to load the settings from
 # Rails.application.config.generators to Rails::Generators
-Rails::Generators.configure!
+Rails::Generators.configure! Rails.application.config.generators
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 


### PR DESCRIPTION
Rails::Generators.configure! doesn't have a default parameter in Rails 3.2. This pull request adds it to make tests run with Rails 3.2.
