### PR TITLE
Updated dependencies for Rails 4.0.0.beta (and Bundler 1.2 as well)

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -15,12 +15,12 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "haml",          "~> 3.1"
-  s.add_dependency "activesupport", "~> 3.1"
-  s.add_dependency "actionpack",    "~> 3.1"
-  s.add_dependency "railties",      "~> 3.1"
+  s.add_dependency "activesupport", [">= 3.1", "< 4.1"]
+  s.add_dependency "actionpack",    [">= 3.1", "< 4.1"]
+  s.add_dependency "railties",      [">= 3.1", "< 4.1"]
 
-  s.add_development_dependency "rails",   "~> 3.1"
-  s.add_development_dependency "bundler", "~> 1.1.0"
+  s.add_development_dependency "rails",   [">= 3.1", "< 4.1"]
+  s.add_development_dependency "bundler", "~> 1.1"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").select{|f| f =~ /^bin/}


### PR DESCRIPTION
Simple change to add "< 4.1" for Rails gems.  This should resolve issue #20.
