### PR TITLE
Fix templates for Rails 4

### DIFF
--- a/lib/generators/haml/scaffold/templates/index.html.haml
+++ b/lib/generators/haml/scaffold/templates/index.html.haml
@@ -16,7 +16,7 @@
 <% end -%>
       %td= link_to 'Show', <%= singular_table_name %>
       %td= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-      %td= link_to 'Destroy', <%= singular_table_name %>, <%= key_value :method, ":delete" %>, <%= key_value :data, "{ #{key_value :confirm, "'Are you sure?'"} }" %>
+      %td= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 


### PR DESCRIPTION
Remove "key_value" helper from index template.

Following is occurred error in scaffolding at current version.

> ```
> (erb):19:in `template': undefined method `key_value' for #<Haml::Generators::ScaffoldGenerator:0x007fb9712be1e8> (NoMethodError)
> ```

Please edit gemspec for Rails4 like "~> 4.0.0.beta" coz it's used the 1.9 hash syntax.
