### PR TITLE
Remove key_vakue helper for rails4

### DIFF
--- a/lib/generators/haml/scaffold/templates/index.html.haml
+++ b/lib/generators/haml/scaffold/templates/index.html.haml
@@ -16,7 +16,7 @@
 <% end -%>
       %td= link_to 'Show', <%= singular_table_name %>
       %td= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-      %td= link_to 'Destroy', <%= singular_table_name %>, <%= key_value :method, ":delete" %>, <%= key_value :data, "{ #{key_value :confirm, "'Are you sure?'"} }" %>
+      %td= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 


### PR DESCRIPTION
I use haml-rails with rails 4.0.0.beta and I have come across following error when I generated some scaffold.

```
% rails g scaffold product
      invoke  active_record
      create    db/migrate/20121115070833_create_products.rb
   identical    app/models/product.rb
      invoke    test_unit
   identical      test/models/product_test.rb
   identical      test/fixtures/products.yml
      invoke  resource_route
       route    resources :products
      invoke  scaffold_controller
   identical    app/controllers/products_controller.rb
      invoke    haml
       exist      app/views/products
(erb):19:in `template': undefined method `key_value' for #<Haml::Generators::ScaffoldGenerator:0x000000129ca2e0> (NoMethodError)
        from /usr/local/rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/erb.rb:838:in `eval'
        from /usr/local/rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/erb.rb:838:in `result'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/file_manipulation.rb:111:in `block in template'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:54:in `call'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:54:in `render'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:47:in `identical?'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:73:in `on_conflict_behavior'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/empty_directory.rb:130:in `invoke_with_conflict_check'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:61:in `invoke!'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions.rb:95:in `action'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/create_file.rb:26:in `create_file'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/actions/file_manipulation.rb:110:in `template'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/generators/named_base.rb:24:in `block in template'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/generators/named_base.rb:53:in `inside_template'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/generators/named_base.rb:23:in `template'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/haml-rails-0.3.5/lib/generators/haml/scaffold/scaffold_generator.rb:11:in `block in copy_view_files'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/haml-rails-0.3.5/lib/generators/haml/scaffold/scaffold_generator.rb:9:in `each'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/haml-rails-0.3.5/lib/generators/haml/scaffold/scaffold_generator.rb:9:in `copy_view_files'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `block in invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `each'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `map'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:238:in `dispatch'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:109:in `invoke'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:281:in `block in _invoke_for_class_method'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/shell.rb:74:in `with_padding'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:270:in `_invoke_for_class_method'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:150:in `_invoke_from_option_template_engine'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `block in invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `each'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `map'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:238:in `dispatch'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:109:in `invoke'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:281:in `block in _invoke_for_class_method'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/shell.rb:74:in `with_padding'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:270:in `_invoke_for_class_method'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:150:in `_invoke_from_option_scaffold_controller'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/task.rb:27:in `run'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:120:in `invoke_task'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `block in invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `each'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `map'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/invocation.rb:126:in `invoke_all'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/group.rb:238:in `dispatch'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/gems/thor-0.16.0/lib/thor/base.rb:425:in `start'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/generators.rb:157:in `invoke'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/commands/generate.rb:11:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/activesupport/lib/active_support/dependencies.rb:227:in `require'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/activesupport/lib/active_support/dependencies.rb:227:in `block in require'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/activesupport/lib/active_support/dependencies.rb:212:in `load_dependency'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/activesupport/lib/active_support/dependencies.rb:227:in `require'
        from /usr/local/rvm/gems/ruby-1.9.3-p194@rails4/bundler/gems/rails-2f3d81c764a8/railties/lib/rails/commands.rb:51:in `<top (required)>'
        from script/rails:6:in `require'
        from script/rails:6:in `<main>'
```

Because rails generators were modified in following commit:
https://github.com/rails/rails/commit/1ced5ca67bc553ebc4a8a1b3ba4776e882587600

So we should always use the 1.9 syntax.
