### PR TITLE
Bump stable Haml version

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "haml-rails"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "haml",          [">= 3.1", "< 3.2"]
+  s.add_dependency "haml",          [">= 3.1", "< 4.1"]
   s.add_dependency "activesupport", [">= 3.1", "< 4.1"]
   s.add_dependency "actionpack",    [">= 3.1", "< 4.1"]
   s.add_dependency "railties",      [">= 3.1", "< 4.1"]


### PR DESCRIPTION
I'm going to release the next stable version of Haml this Wednesday at 13:00 UTC, so I thought I'd give you a heads up and update your gemspec for whenever you're ready to allow the new version as a dependency.

Note that the new version will now be 4.0.0 rather than 3.2.0 because we've adopted semantic versioning, and are bumping the major number because of some breaking changes introduced in the new release.
