### PR TITLE
Support Gem::Version properly

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -4,7 +4,7 @@ require 'rails'
 module Haml
   module Rails
     class Railtie < ::Rails::Railtie
-      if ::Rails.version.to_f >= 3.1
+      if ::Rails.version.to_s >= "3.1"
         config.app_generators.template_engine :haml
       else
         config.generators.template_engine :haml


### PR DESCRIPTION
I haven't tested this with rails < 4-master, but this fixes breakage where Rails.version now returns a Gem::Version and these comparisons fail there.  This is the offending commit afaict: https://github.com/rails/rails/commit/c07e1515f7c66f5599cbb3c7e9fe42e166bf3edc
