### PR TITLE
add support for view template cache digestion via Rails 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ To use it, add this line to your Gemfile:
 
     gem "haml-rails"
 
-Pretty fancy, eh?
+This ensures that:
+  * Any time you generate a controller or scaffold, you'll get Haml templates (instead of ERB)
+  * When your Rails application loads, Haml will be loaded and initialized automatically
+  * Haml templates will be respected by the view template cache digestor
 
-Once you've done that, any time you generate a controller or scaffold, you'll get Haml instead of ERB templates. On top of that, when your Rails application loads, Haml will be loaded and initialized completely automatically! The modern world is just so amazing.
+Pretty fancy, eh? The modern world is just so amazing.
 
 ### Contributors
 

--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -14,6 +14,50 @@ module Haml
         Haml.init_rails(binding)
         Haml::Template.options[:format] = :html5
       end
+
+      initializer 'haml_rails.configure_template_digestor' do
+        # Configure cache digests to parse haml view templates
+        # when calculating cache keys for view fragments
+
+        ActiveSupport.on_load(:action_view) do
+          ActiveSupport.on_load(:after_initialize) do
+            begin
+              if defined?(CacheDigests::DependencyTracker)
+                # 'cache_digests' gem being used (overrides Rails 4 implementation)
+                CacheDigests::DependencyTracker.register_tracker :haml, CacheDigests::DependencyTracker::ERBTracker
+
+                if ::Rails.env.development?
+                  # recalculate cache digest keys for each request
+                  CacheDigests::TemplateDigestor.cache = ActiveSupport::Cache::NullStore.new
+                end
+              else
+                # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
+                require 'action_view/dependency_tracker'
+                ActionView::DependencyTracker.register_tracker :haml, ActionView::DependencyTracker::ERBTracker
+
+                if ::Rails.env.development?
+                  # recalculate cache digest keys for each request
+
+                  # using blackhole cache until code is released to allow us to get this behavior
+                  # by simply setting `config.action_view.cache_template_loading` false in development.rb
+                  # https://github.com/rails/rails/pull/10791
+                  class BlackHole < Hash
+                    def []=(*); end
+                  end
+                  module ::ActionView
+                    class Digestor
+                      @@cache = BlackHole.new
+                    end
+                  end
+                end
+              end
+            rescue
+              # likely this version of Rails doesn't support dependency tracking
+              # so, we can't parse haml templates without 'cache_digests' gem anyway :)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/indirect/haml-rails/issues/50 this PR adds support for Haml template digestion in Rails 4 and Rails 3.x with DHH's `cache_digests` gem.
