### PR TITLE
make BlackHole to mimic ThreadSafe::Cache methods

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -43,7 +43,11 @@ module Haml
                   # https://github.com/rails/rails/pull/10791
                   class BlackHole < Hash
                     def []=(*); end
+                    def put_if_absent(*); end
+                    def fetch(*); yield; end
+                    def delete_pair(*); end
                   end
+
                   module ::ActionView
                     class Digestor
                       @@cache = BlackHole.new


### PR DESCRIPTION
This adds compatibility with [Rails 4.0.1 Digestor](https://github.com/rails/rails/blob/v4.0.1/actionpack/lib/action_view/digestor.rb)
