### PR TITLE
Use ActiveSupport::Cache::NullStore instead of custom BlackHole

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -34,26 +34,7 @@ module Haml
                 # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
                 require 'action_view/dependency_tracker'
                 ActionView::DependencyTracker.register_tracker :haml, ActionView::DependencyTracker::ERBTracker
-
-                if ::Rails.env.development?
-                  # recalculate cache digest keys for each request
-
-                  # using blackhole cache until code is released to allow us to get this behavior
-                  # by simply setting `config.action_view.cache_template_loading` false in development.rb
-                  # https://github.com/rails/rails/pull/10791
-                  class BlackHole < Hash
-                    def []=(*); end
-                    def put_if_absent(*); end
-                    def fetch(*); yield; end
-                    def delete_pair(*); end
-                  end
-
-                  module ::ActionView
-                    class Digestor
-                      @@cache = BlackHole.new
-                    end
-                  end
-                end
+                ActionView::Digestor.cache = ActiveSupport::Cache::NullStore.new if ::Rails.env.development?
               end
             rescue
               # likely this version of Rails doesn't support dependency tracking


### PR DESCRIPTION
I can't see a reason to not use the available NullStore.

The BackHole store causes stack level overflow issues for me with a recursively nested partial. Works fine with NullStore.
