### PR TITLE
Use ActionView::Base.cache_template_loading to avoid caching

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,5 @@ appraise "rails_3_2" do
 end
 
 appraise "rails_4_0" do
-  gem "rails", "~> 4.0.0"
+  gem "rails", "~> 4.0.1"
 end

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0.0"
+gem "rails", "~> 4.0.1"
 
 gemspec :path=>"../"

--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "haml",          [">= 3.1", "< 5.0"]
-  s.add_dependency "activesupport", ["~> 4.0.0"]
-  s.add_dependency "actionpack",    ["~> 4.0.0"]
-  s.add_dependency "railties",      ["~> 4.0.0"]
+  s.add_dependency "activesupport", ["~> 4.0.1"]
+  s.add_dependency "actionpack",    ["~> 4.0.1"]
+  s.add_dependency "railties",      ["~> 4.0.1"]
 
-  s.add_development_dependency "rails",   ["~> 4.0.0"]
+  s.add_development_dependency "rails",   ["~> 4.0.1"]
   s.add_development_dependency "bundler", "~> 1.2"
   s.add_development_dependency "rake"
   s.add_development_dependency 'appraisal', '>= 0.3.8'

--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -34,7 +34,7 @@ module Haml
                 # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
                 require 'action_view/dependency_tracker'
                 ActionView::DependencyTracker.register_tracker :haml, ActionView::DependencyTracker::ERBTracker
-                ActionView::Digestor.cache = ActiveSupport::Cache::NullStore.new if ::Rails.env.development?
+                ActionView::Base.cache_template_loading = false if ::Rails.env.development?
               end
             rescue
               # likely this version of Rails doesn't support dependency tracking


### PR DESCRIPTION
I just had another look and it seems like #56 was much too fast yesterday. It actually does not work, since the cache attribute is not writable anymore in Rails 4. It in fact causes an exception, which I did not see since it's caught somewhere.

Nevertheless, https://github.com/rails/rails/pull/10791 is available since 4.0.1, so here is my try to make use of it. Could you please have a look at it and comment on this change, @eprothro and @Mik-die.

As I said, the BlackHole implementation causes issues for me, so it's definitely not ideal.
