### PR TITLE
edge rails argument error

### DIFF
--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.add_dependency "haml",          [">= 3.1", "< 5.0"]
   s.add_dependency "activesupport", [">= 4.0.1"]
   s.add_dependency "actionpack",    [">= 4.0.1"]
-  s.add_dependency "railties",      [">= 4.0.1"]
+  s.add_dependency "railties",      ["4.1.0.rc1"]
 
-  s.add_development_dependency "rails",   [">= 4.0.1"]
+  s.add_development_dependency "rails",   ["4.1.0.rc1"]
   s.add_development_dependency "bundler", "~> 1.2"
   s.add_development_dependency "rake"
   s.add_development_dependency 'appraisal', '>= 0.3.8'

--- a/lib/generators/haml/scaffold/scaffold_generator.rb
+++ b/lib/generators/haml/scaffold/scaffold_generator.rb
@@ -7,7 +7,7 @@ module Haml
 
       def copy_view_files
         available_views.each do |view|
-          filename = filename_with_extensions(view)
+          filename = filename_with_extensions(view, :html)
           template "#{view}.html.haml", File.join("app/views", controller_file_path, filename)
         end
       end
@@ -16,7 +16,7 @@ module Haml
 
       def copy_form_file
         if options[:form_builder].nil?
-          filename = filename_with_extensions("_form")
+          filename = filename_with_extensions("_form", :html)
           template "_form.html.haml", File.join("app/views", controller_file_path, filename)
         end
       end


### PR DESCRIPTION
Fixes this error for rails 4.1.0rc1 ( or we could give it a default "html" in rails, but I just put this here because I got there error from haml-rails ).

<pre>
  3) Error:
Haml::Generators::ScaffoldGeneratorTest#test_should_revoke_template_engine:
ArgumentError: wrong number of arguments (1 for 2)
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/railties-4.1.0.rc1/lib/rails/generators/erb.rb:20:in `filename_with_extensions'
    /Users/shair/projects/haml-rails/lib/generators/haml/scaffold/scaffold_generator.rb:10:in `block in copy_view_files'
    /Users/shair/projects/haml-rails/lib/generators/haml/scaffold/scaffold_generator.rb:9:in `each'
    /Users/shair/projects/haml-rails/lib/generators/haml/scaffold/scaffold_generator.rb:9:in `copy_view_files'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:233:in `dispatch'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:109:in `invoke'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:278:in `block in _invoke_for_class_method'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/shell.rb:74:in `with_padding'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:267:in `_invoke_for_class_method'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:134:in `_invoke_from_option_template_engine'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:233:in `dispatch'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:109:in `invoke'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:278:in `block in _invoke_for_class_method'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/shell.rb:74:in `with_padding'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:267:in `_invoke_for_class_method'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:134:in `_invoke_from_option_scaffold_controller'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/command.rb:27:in `run'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:120:in `invoke_command'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `block in invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `each'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `map'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/invocation.rb:127:in `invoke_all'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/group.rb:233:in `dispatch'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/thor-0.18.1/lib/thor/base.rb:439:in `start'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/railties-4.1.0.rc1/lib/rails/generators/testing/behaviour.rb:66:in `block in run_generator'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/activesupport-4.1.0.rc1/lib/active_support/core_ext/kernel/reporting.rb:89:in `capture'
    /Users/shair/.rvm/gems/ruby-2.1.1/gems/railties-4.1.0.rc1/lib/rails/generators/testing/behaviour.rb:64:in `run_generator'
    /Users/shair/projects/haml-rails/test/lib/generators/haml/scaffold_generator_test.rb:20:in `block in <class:ScaffoldGeneratorTest>'
</pre>
