### PR TITLE
Update documentation to clarify rails version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Haml-rails
 
-Haml-rails provides Haml generators for Rails 3. It also enables Haml as the templating engine for you, so you don't have to screw around in your own application.rb when your Gemfile already clearly indicated what templating engine you have installed. Hurrah.
+Haml-rails provides Haml generators for Rails 4. It also enables Haml as the templating engine for you, so you don't have to screw around in your own application.rb when your Gemfile already clearly indicated what templating engine you have installed. Hurrah.
 
 To use it, add this line to your Gemfile:
 
@@ -12,6 +12,14 @@ This ensures that:
   * Haml templates will be respected by the view template cache digestor
 
 Pretty fancy, eh? The modern world is just so amazing.
+
+### Older versions of Rails
+
+The current version of Haml-rails requires 4.0.1 or later.
+
+Haml-rails version 0.4 is the last version to support Rails 3. To use it, add this line to your Gemfile:
+
+    gem "haml-rails", "~> 0.4.0"
 
 ### Contributors
 

--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email       = ["andre@arko.net"]
   s.homepage    = "http://github.com/indirect/haml-rails"
   s.summary     = "let your Gemfile do the configuring"
-  s.description = "Haml-rails provides Haml generators for Rails 3. It also enables Haml as the templating engine for you, so you don't have to screw around in your own application.rb when your Gemfile already clearly indicated what templating engine you have installed. Hurrah."
+  s.description = "Haml-rails provides Haml generators for Rails 4. It also enables Haml as the templating engine for you, so you don't have to screw around in your own application.rb when your Gemfile already clearly indicated what templating engine you have installed. Hurrah."
   s.licenses    = ["MIT"]
 
   s.rubyforge_project         = "haml-rails"


### PR DESCRIPTION
Hey Andre, I was looking at this gem's page on rubygems.org and it said "for rails 3" so I tried to update to the latest version within a rails 3 project, and then I had a sad since this gem is now for 4+ only.

So I updated your docs for you! :yellow_heart: :purple_heart: :green_heart: 
