### PR TITLE
require haml/railtie explictly

### DIFF
--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -1,5 +1,6 @@
 require 'haml'
 require 'rails'
+require 'haml/railtie'
 
 module Haml
   module Rails


### PR DESCRIPTION
`haml` loads `haml/engine` only if `Rails::Railtie` is defined and `haml/engine` loads `haml/template`.
https://github.com/haml/haml/blob/4.1.0.beta.1/lib/haml.rb#L23

[Some libraries](https://github.com/gongo/turnip_formatter) may `require "haml"` before boot rails.

It causes error like below:

```
/opt/boxen/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/haml-rails-0.5.3/lib/haml-rails.rb:15:in `block in <class:Railtie>': uninitialized constant Haml::Template (NameError)
```
