### PR TITLE
Added Rails generator command: rails g haml:application_layout convert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'rubysl', '~> 2.0', platforms: :rbx
 gem 'minitest', platforms: :rbx
+gem 'html2haml'

--- a/haml-rails.gemspec
+++ b/haml-rails.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", [">= 4.0.1"]
   s.add_dependency "actionpack",    [">= 4.0.1"]
   s.add_dependency "railties",      [">= 4.0.1"]
+  s.add_dependency "html2haml",     [">= 1.0.1"]
 
   s.add_development_dependency "rails",   [">= 4.0.1"]
   s.add_development_dependency "bundler", "~> 1.2"

--- a/lib/rails/generators/haml/application_layout/application_layout_generator.rb
+++ b/lib/rails/generators/haml/application_layout/application_layout_generator.rb
@@ -1,0 +1,31 @@
+require 'rails'
+
+module Haml
+  module Generators
+    class ApplicationLayoutGenerator < ::Rails::Generators::Base
+
+      # Converts existing application.html.erb to haml format,
+      # and creates app/views/layouts/application.html.haml
+      # with some error checking.
+      def convert
+        app_layout_from = ::Rails.root.join('app/views/layouts/application.html.erb')
+        app_layout_to   = ::Rails.root.join('app/views/layouts/application.html.haml')
+
+        if File.exist?(app_layout_from)
+
+          if !File.exist?(app_layout_to)
+            `html2haml #{app_layout_from} #{app_layout_to}`
+            puts "Success! app/views/layouts/application.html.haml is created.\n" \
+                 "Please remove the erb file: app/views/layouts/application.html.erb"
+          else
+            puts "Error! There is a file named app/views/layouts/application.html.haml already."
+          end
+        else
+          puts "Error! There is no file named app/views/layouts/application.html.erb."
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
PR for #47 

Usage
Once you install haml-rails gem, you can run the following command
to convert application.html.erb to application.html.haml.

`$ rails generate haml:application_layout convert`
or
`$ rails g haml:application_layout convert`
