### PR TITLE
CI: Drop  Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
   See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details