### PR TITLE
CI: Use ruby 2.4.7 in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 rvm:
   - 2.6.4
   - 2.5.6
-  - 2.4.6
+  - 2.4.7
   - 2.3.8
   - jruby-9.2.8.0
 gemfile:
@@ -17,6 +17,6 @@ matrix:
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/rails_6.rc1.gemfile
-    - rvm: 2.4.6
+    - rvm: 2.4.7
       gemfile: gemfiles/rails_6.rc1.gemfile
 script: "bundle exec rake test"


### PR DESCRIPTION
This PR updates the build matrix to include the latest 2.4 release.

This was left out of #166.