### PR TITLE
Remove duplicate mailer suffixes

### DIFF
--- a/lib/generators/haml/mailer/mailer_generator.rb
+++ b/lib/generators/haml/mailer/mailer_generator.rb
@@ -1,42 +1,14 @@
-require 'generators/haml/controller/controller_generator'
+require 'rails/generators/erb/mailer/mailer_generator'
 
 module Haml
   module Generators
-    class MailerGenerator < ControllerGenerator
+    class MailerGenerator < Erb::Generators::MailerGenerator
       source_root File.expand_path("../templates", __FILE__)
 
-      def copy_view_files
-        if ::Rails.version.to_s >= "4.2.0"
-          view_base_path = File.join("app/views", class_path, file_name + "_mailer")
-          empty_directory view_base_path
+      protected
 
-          if behavior == :invoke
-            formats.each do |format|
-              layout_path = File.join("app/views/layouts", class_path, filename_with_extensions("mailer", format))
-              template filename_with_extensions(:layout, format), layout_path unless File.exist?(layout_path)
-            end
-          end
-
-          actions.each do |action|
-            @action = action
-
-            formats.each do |format|
-              @path = File.join(view_base_path, filename_with_extensions(action, format))
-              template filename_with_extensions(:view, format), @path
-            end
-          end
-        else
-          super
-        end
-      end
-
-    protected
-      def format
-        :text
-      end
-
-      def formats
-        [:text, :html]
+      def handler
+        :haml
       end
     end
   end

--- a/test/lib/generators/haml/mailer_generator_test.rb
+++ b/test/lib/generators/haml/mailer_generator_test.rb
@@ -65,4 +65,23 @@ class Haml::Generators::MailerGeneratorTest < Rails::Generators::TestCase
       end
     end
   end
+
+  test 'suffix is not duplicated' do
+    if ::Rails.version.to_s >= '4.2'
+      run_generator ['notifier_mailer', 'foo', 'bar', '--template-engine', 'haml']
+
+      assert_no_file 'app/views/notifier_mailer_mailer/'
+      assert_file 'app/views/notifier_mailer/'
+
+      assert_no_file 'app/views/notifier_mailer_mailer/foo.text.haml'
+      assert_file 'app/views/notifier_mailer/foo.text.haml'
+      assert_no_file 'app/views/notifier_mailer_mailer/foo.html.haml'
+      assert_file 'app/views/notifier_mailer/foo.html.haml'
+
+      assert_no_file 'app/views/notifier_mailer_mailer/bar.text.haml'
+      assert_file 'app/views/notifier_mailer/bar.text.haml'
+      assert_no_file 'app/views/notifier_mailer_mailer/bar.html.haml'
+      assert_file 'app/views/notifier_mailer/bar.html.haml'
+    end
+  end
 end


### PR DESCRIPTION
First of all, thanks for `haml-rails`!

This PR fixes an issue I ran into, where generating a mailer did not work correctly. Here's what the issue looks like:

```
λ bin/rails generate mailer UserMailer
Running via Spring preloader in process 14169
      create  app/mailers/user_mailer.rb
      invoke  haml
      create    app/views/user_mailer_mailer <-- This doesn't match!
      invoke  test_unit
      create    test/mailers/user_mailer_test.rb
      create    test/mailers/previews/user_mailer_preview.rb
```

The views directory (and any actions created inside it) have the duplicated `_mailer_mailer` suffix, and the mailer will error and not be able to find the views because the names do not match. The ERB generator, like all other Rails generators, [strips these suffixes](https://github.com/rails/rails/blob/c81af6ae723ccfcd601032167d7b7f57c5449c33/railties/lib/rails/generators/erb/mailer/mailer_generator.rb#L36-L38), but `haml-rails` does not, which is why there is a discrepancy.

This PR adds a test to make sure duplicate suffixes are handled, and fixes the issue (and simplifies the code) by inheriting from the ERB mailer generator.