### PR TITLE
updated readme to reflect that html2haml is no longer part of the haml-rails install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ to `app/views/layouts/application.html.haml` using this command:
 
     $ rails generate haml:application_layout convert
 
+This requires the html2haml gem and you can install it locally:
+
+    gem install html2haml
+
 After the application layout file is converted successfully,
 make sure to delete `app/views/layouts/application.html.erb`, so Rails can
 start using `app/views/layouts/application.html.haml` instead.


### PR DESCRIPTION
As per our discussion [here](https://github.com/haml/haml-rails/issues/182). This is my first ever public repo contribution so let me know if there are any issues. Modify as per your needs.