### PR TITLE
use rails helpers for resource routes

### DIFF
--- a/lib/generators/haml/scaffold/templates/_form.html.haml
+++ b/lib/generators/haml/scaffold/templates/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @<%= singular_table_name %> do |f|
+= form_for @<%= singular_table_name %><%= plural_table_name == index_helper ? '' : ", url: #{index_helper}_path" %> do |f|
   - if @<%= singular_table_name %>.errors.any?
     #error_explanation
       %h2= "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:"

--- a/lib/generators/haml/scaffold/templates/edit.html.haml
+++ b/lib/generators/haml/scaffold/templates/edit.html.haml
@@ -2,6 +2,6 @@
 
 = render 'form'
 
-= link_to 'Show', @<%= singular_table_name %>
+= link_to 'Show', <%= show_helper(type: :path) %>
 \|
 = link_to 'Back', <%= index_helper %>_path

--- a/lib/generators/haml/scaffold/templates/index.html.haml
+++ b/lib/generators/haml/scaffold/templates/index.html.haml
@@ -16,10 +16,10 @@
 <% for attribute in attributes -%>
         %td= <%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
-        %td= link_to 'Show', <%= singular_table_name %>
-        %td= link_to 'Edit', edit_<%= singular_table_name %>_path(<%= singular_table_name %>)
-        %td= link_to 'Destroy', <%= singular_table_name %>, method: :delete, data: { confirm: 'Are you sure?' }
+        %td= link_to 'Show', <%= show_helper(singular_table_name, type: :path) %>
+        %td= link_to 'Edit', <%= edit_helper(singular_table_name, type: :path) %>
+        %td= link_to 'Destroy', <%= show_helper(singular_table_name, type: :path) %>, method: :delete, data: { confirm: 'Are you sure?' }
 
 %br
 
-= link_to 'New <%= human_name %>', new_<%= singular_table_name %>_path
+= link_to 'New <%= human_name %>', <%= new_helper(type: :path) %>

--- a/lib/generators/haml/scaffold/templates/show.html.haml
+++ b/lib/generators/haml/scaffold/templates/show.html.haml
@@ -6,6 +6,6 @@
   = @<%= singular_table_name %>.<%= attribute.name %>
 <% end -%>
 
-= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+= link_to 'Edit', <%= edit_helper(type: :path) %>
 \|
 = link_to 'Back', <%= index_helper %>_path


### PR DESCRIPTION
I encountered some issues when using Rails scaffolding with a model name/namespace that didn't match up. Ie. scaffolding admin routes for some resources like this:

```
rails generate scaffold admin/user name:string --model-name="User"
```
This should generate everything using a `User` model, but with routing that follows `admin_user*` naming pattern. However, the templates would generate links with `user*` for paths.

This updates the templates to use the rest of the routing helpers Rails provides, and also includes a handler for the form target url, only if necessary.