### PR TITLE
Adds Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.2
           - 3.1
-          - 3.0
+          - "3.0"
           - 2.7
           - jruby
         gemfile:
@@ -47,6 +48,8 @@ jobs:
         exclude:
           - ruby-version: jruby
             gemfile: rails_7_0
+          - ruby-version: 3.2
+            gemfile: rails_6_0
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
Also quotes 3.0 so it isn't truncated to 3.  This is necessary because an unquoted 3.0 in a GitHub Actions configuration is truncated to "3", which then loads the latest Ruby 3 - at time of writing Ruby 3.2.  That's not what's intended.

Runs green on my fork.