### PR TITLE
fix: improve error handling in erb2haml task

### DIFF
--- a/lib/tasks/erb2haml.rake
+++ b/lib/tasks/erb2haml.rake
@@ -4,6 +4,7 @@ namespace :haml do
 
     erb_files = Dir.glob('app/views/**/*.erb').select { |f| File.file? f}
     haml_files = Dir.glob('app/views/**/*.haml').select { |f| File.file? f}
+    failed_files = []
 
     if erb_files.empty?
       puts "No .erb files found. Task will now exit."
@@ -52,13 +53,27 @@ namespace :haml do
     erb_files_to_convert.each do |file|
       puts "Generating HAML for #{file}..."
       `html2haml #{file} #{file.gsub(/\.erb\z/, '.haml')}`
+      if !$?.success?
+        puts "Error: html2haml failed to convert #{file} to HAML. Please check the file for errors."
+        failed_files << file
+      end
     end
+
+    successful_files = erb_files_to_convert - failed_files
 
     puts '-'*80
 
     puts "HAML generated for the following files:"
-    erb_files_to_convert.each do |file|
+    successful_files.each do |file|
       puts "\t#{file}"
+    end
+
+    if failed_files.any?
+      puts "The following files failed to convert:"
+      failed_files.each do |file|
+        puts "\t#{file}"
+      end
+      puts "Please check the above files for errors and that you have html2haml installed properly."
     end
 
     puts '-'*80
@@ -66,13 +81,15 @@ namespace :haml do
       should_delete = 'y'
     else
       begin
-        puts 'Would you like to delete the original .erb files? (This is not recommended unless you are under version control.) (y/n)'
+        puts 'Would you like to delete the original .erb files that successfully converted? (This is not recommended unless you are under version control.) (y/n)'
         should_delete = STDIN.gets.chomp.downcase[0]
       end until ['y', 'n'].include?(should_delete)
     end
-    if should_delete == 'y'
+    if should_delete == 'y' && successful_files.any?
       puts "Deleting original .erb files."
-      File.delete(*erb_files)
+      File.delete(*successful_files)
+    elsif should_delete == 'y' && successful_files.empty?
+      puts "No successfully converted files to delete."
     else
       puts "Please remember to delete your .erb files once you have ensured they were translated correctly."
     end


### PR DESCRIPTION
- Added error message when html2haml conversion fails for a file.
- Updated successful file tracking to only include files that converted without errors.
- Enhanced user prompt for deleting original .erb files to specify only those that successfully converted.

closes #193 