### PR TITLE
Use :ruby render tracker for haml cache dependency detection on Rails 8.1+

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.2'
           - '3.1'
         rails-version:
+          - '8.1'
           - '8.0'
           - '7.2'
           - '7.1'
@@ -63,6 +64,8 @@ jobs:
             rails-version: '6.1'
 
         exclude:
+          - ruby-version: '3.1'
+            rails-version: '8.1'
           - ruby-version: '3.1'
             rails-version: '8.0'
 

--- a/lib/haml-rails.rb
+++ b/lib/haml-rails.rb
@@ -31,7 +31,13 @@ module Haml
               else
                 # will only apply if Rails 4, which includes 'action_view/dependency_tracker'
                 require 'action_view/dependency_tracker'
-                ActionView::DependencyTracker.register_tracker :haml, ActionView::DependencyTracker::ERBTracker
+                tracker = if defined?(ActionView::DependencyTracker::RubyTracker)
+                            # Rails 8.1+ RubyTracker compiles templates to Ruby before parsing
+                            ActionView::DependencyTracker::RubyTracker
+                          else
+                            ActionView::DependencyTracker::ERBTracker
+                          end
+                ActionView::DependencyTracker.register_tracker :haml, tracker
                 ActionView::Base.cache_template_loading = false if ::Rails.env.development?
               end
             rescue


### PR DESCRIPTION
[Rails 8.1 tightened ERBTracker](https://github.com/rails/rails/pull/55165) to only match render calls inside ERB `<% %>` tags, which breaks cache dependency detection for Haml templates. Changes to partials no longer bust the cache of parent templates that render them.

Rails 8.1 also introduced a :ruby render tracker strategy that compiles templates to Ruby via the registered handler before parsing for render calls. 

Fixes #199